### PR TITLE
'users' should be singular not plural

### DIFF
--- a/articles/user-profile/normalized.md
+++ b/articles/user-profile/normalized.md
@@ -41,7 +41,7 @@ The `identities` array contains the following attributes:
 
 When outsourcing user authentication, there generally is no need to keep a Users/Passwords table. Even so, you might still want to associate application data to authenticated users.
 
-For example, you could have a **Users table** that would have a copy of each user authenticated by Auth0. Every time a users logs in, you would search the table for that user. If the user does not exist, you would create a new record. If it does exist, you would update all fields, essentially keeping a local copy of the user data.
+For example, you could have a **Users table** that would have a copy of each user authenticated by Auth0. Every time a user logs in, you would search the table for that user. If the user does not exist, you would create a new record. If it does exist, you would update all fields, essentially keeping a local copy of the user data.
 
 Alternatively, you might store the user identifier on each table/collection that has user-associated data. For smaller applications, that's often simpler to implement.
 


### PR DESCRIPTION
### Your checklist for this pull request

Please review the [guidelines for contributing](https://github.com/auth0/docs#contributing) to this repository.
- [x] Content conforms to our [Contributing Guidelines](https://github.com/auth0/docs#contributing-guidelines)
- [x] If applicable, you have added details to the [update feed](https://github.com/auth0/docs/tree/master/updates) 

If you are an Auth0 employee, after you submit this PR create and test a [Review App](https://github.com/auth0/docs#review-apps) to test your changes.
### Description

Incorrect Grammar @ https://auth0.com/docs/user-profile/normalized
(it's the second sentence in the paragraph below... 'users' should be singular, not plural)
_For example, you could have a Users table that would have a copy of each user authenticated by Auth0. Every time a users logs in, you would search the table for that user._

Thank you!
